### PR TITLE
Add login option for OSX

### DIFF
--- a/LinuxPty.py
+++ b/LinuxPty.py
@@ -7,7 +7,7 @@ import termios
 
 
 class LinuxPty():
-    def __init__(self, cmd):
+    def __init__(self, *cmd):
         self._cmd = cmd
         self._env = os.environ.copy()
         self._env["TERM"] = "linux"

--- a/TerminalView.py
+++ b/TerminalView.py
@@ -35,7 +35,13 @@ class TerminalViewCore(sublime_plugin.TextCommand):
         self._terminal_rows = 0
         self._terminal_columns = 0
 
-        self._shell = LinuxPty.LinuxPty("/bin/bash")
+        if sublime.platform() == "linux":
+            self._shell = LinuxPty.LinuxPty("/bin/bash")
+        elif sublime.platform() == "osx":
+            self._shell = LinuxPty.LinuxPty("/bin/bash", "-l")
+        else: # sublime.platform() == "windows"
+            sublime.error_message("Windows not supported!")
+            return
         self._shell_is_running = True
 
         self._schedule_call_to_check_for_screen_resize()


### PR DESCRIPTION
This PR adds proper support for OSX (I believe this is all that's needed). If the `-l` option is omitted then some environment variables are missing. Most notably stuff from `/usr/local/bin`.