### PR TITLE
Make sure windows users get an error message for now

### DIFF
--- a/LinuxPty.py
+++ b/LinuxPty.py
@@ -2,11 +2,15 @@ import os
 import select
 import subprocess
 import struct
-import fcntl
-import termios
+import sublime
+if sublime.platform() in ("linux", "osx"):
+    import fcntl
+    import termios
+elif sublime.platform() == "windows":
+    pass
+    # TODO
 
-
-class LinuxPty():
+class LinuxPty(object):
     def __init__(self, *cmd):
         self._cmd = cmd
         self._env = os.environ.copy()

--- a/TerminalView.py
+++ b/TerminalView.py
@@ -21,9 +21,12 @@ from . import utils
 # TerminalViewCore instance for that view is called to handle everything.
 class TerminalViewOpen(sublime_plugin.WindowCommand):
     def run(self):
-        win = sublime.active_window()
-        view = win.new_file()
-        view.run_command("terminal_view_core")
+        if sublime.platform() in ("linux", "osx"):
+            win = sublime.active_window()
+            view = win.new_file()
+            view.run_command("terminal_view_core")
+        elif sublime.platform() == "windows":
+            sublime.error_message("Windows not supported!")
 
 
 # Main command to glue everything together. One instance of this per view.


### PR DESCRIPTION
When windows users attempt to start a terminal an error message will pop up
saying that windows is not supported at the moment.