### PR TITLE
Open terminal in a sensible directory

### DIFF
--- a/LinuxPty.py
+++ b/LinuxPty.py
@@ -7,14 +7,15 @@ import termios
 
 
 class LinuxPty():
-    def __init__(self, *cmd):
+    def __init__(self, working_dir=None, *cmd):
         self._cmd = cmd
         self._env = os.environ.copy()
         self._env["TERM"] = "linux"
         (self._pty, self._pts) = os.openpty()
         self._process = subprocess.Popen(self._cmd, stdin=self._pts,
                                          stdout=self._pts, stderr=self._pts, shell=False,
-                                         env=self._env, close_fds=True, preexec_fn=os.setsid)
+                                         env=self._env, close_fds=True, preexec_fn=os.setsid,
+                                         cwd=working_dir)
 
     def stop(self):
         if self.is_running():

--- a/TerminalView.py
+++ b/TerminalView.py
@@ -13,12 +13,11 @@ from . import utils
 # colors
 # maybe reset terminal on resize ?
 
-class TerminalViewOpen(sublime_plugin.TextCommand):
+class TerminalViewOpen(sublime_plugin.WindowCommand):
     """Main command to glue everything together. One instance of this per view.
     """
 
     def run(self, 
-            edit, 
             cmd="/bin/bash -l", 
             title="Terminal", 
             cwd="${project_path:${folder:${file_path}}}"):
@@ -36,11 +35,10 @@ class TerminalViewOpen(sublime_plugin.TextCommand):
         if sublime.platform() not in ("linux", "osx"):
             sublime.error_message("TerminalView: Unsupported OS")
             return
-        window = self.view.window()
-        cwd = sublime.expand_variables(cwd, window.extract_variables())
+        cwd = sublime.expand_variables(cwd, self.window.extract_variables())
         if not cwd:
             cwd = os.environ["HOME"]
-        window.new_file().run_command("terminal_view_core", 
+        self.window.new_file().run_command("terminal_view_core", 
                 args={"cmd": cmd, "title": title, "cwd": cwd})
 
 class TerminalViewCore(sublime_plugin.TextCommand):

--- a/TerminalView.py
+++ b/TerminalView.py
@@ -14,7 +14,10 @@ from . import utils
 # maybe reset terminal on resize ?
 
 class TerminalViewOpen(sublime_plugin.WindowCommand):
-    """Main command to glue everything together. One instance of this per view.
+    """
+    Main entry command for opening a terminal view. Only one instance of this
+    class per sublime window. Once a terminal view has been opened the
+    TerminalViewCore instance for that view is called to handle everything.
     """
 
     def run(self, 


### PR DESCRIPTION
This PR adds the ability to supply a `cwd` (current working directory), it defaults to sensible values: first it tries the current project folder, then it tries the current "open folder", then it tries the folder of the currently active view, and if even that doesn't work it defaults to the user's home directory.

I merged the stuff from upstream, but I had some merge conflicts. I'm not sure if I have broken anything.