### PR TITLE
Improve the run loop

### DIFF
--- a/TerminalView.py
+++ b/TerminalView.py
@@ -95,9 +95,7 @@ class TerminalViewCore(sublime_plugin.TextCommand):
         # 30 frames per second should be responsive enough
         IDEAL_DELTA = 1.0 / 30.0
         current = time.time()
-        while True:
-            if self._stopped():
-                break
+        while not self._stopped():
             self._poll_shell_output()
             self._refresh_terminal_view()
             self._check_for_screen_resize()


### PR DESCRIPTION
This removes all calls to sublime.set_timeout and replaces it with an update method that runs in a separate thread.

I don't really understand why you have a timeout of 10 milliseconds before constructing the `LinuxPty`; I removed that logic because it seems dangerous. Just do everything in the init method.