### PR TITLE
use TerminalViewManager to manage terminal views

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -20,3 +20,22 @@ class ConsoleLogger():
         if self._enabled:
             prefix = "[terminal_view debug] [%.3f] " % (time.time())
             print(prefix + string)
+
+
+class TerminalViewManager():
+    """
+    A manager to control all TerminalView instance.
+    """
+    @classmethod
+    def register(cls, terminal_view):
+        if not hasattr(cls, "terminal_views"):
+            cls.terminal_views = {}
+        cls.terminal_views[terminal_view.view.id()] = terminal_view
+        return terminal_view
+
+    @classmethod
+    def load_from_id(cls, vid):
+        if vid in cls.terminal_views:
+            return cls.terminal_views[vid]
+        else:
+            raise Exception("terminal view not found.")


### PR DESCRIPTION
Right now, some properties are store is a view object which is not managed by
TerminalView but [sublime_plugin][1]. This is not satisfying, so I added a
TerminalViewManager to store the TerminalView instance.

The instance can be retrieved later for later purposes. Ultimately, the
`view.foo` should be replace by `TerminalViewManager.load_from_id(vid).foo`.

[1]: https://github.com/twolfson/sublime-files/blob/afeed6b8f75ca07ed7f1de80d10a9a2a12764e06/sublime_plugin.py#L196
