### PR TITLE
Revert "send SIGWINCH to the process when resizing"

### DIFF
--- a/linux_pty.py
+++ b/linux_pty.py
@@ -6,7 +6,6 @@ import os
 import select
 import subprocess
 import struct
-import signal
 
 try:
     import fcntl
@@ -67,7 +66,6 @@ class LinuxPty():
             tiocswinsz = getattr(termios, 'TIOCSWINSZ', -2146929561)
             size_update = struct.pack('HHHH', lines, columns, 0, 0)
             fcntl.ioctl(self._pts, tiocswinsz, size_update)
-            os.kill(self._process.pid, signal.SIGWINCH)
 
     def is_running(self):
         """


### PR DESCRIPTION
This reverts commit d2a9e4176afc9a09741900fa8bd9a0587332a738.

It turns out that it is not needed, the issue was caused by zsh.