### PR TITLE
exec command -> terminal_view_exec command

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,62 @@ There are currently no syntax-files provided with the plugin so users must creat
 ## Project switching and ST3 startup
 When switching projects or (re)starting ST3 the plugin restarts all terminals views. Unfortunately, there is no obvious way of restoring earlier sessions so the views are completely reset.
 
+## Running executables interactively through a Sublime build system
+
+In a Sublime build system, you can use the `terminal_view_exec` command for the
+`"target"` key. You can then use the keyboard to give input to whatever
+executable that you're running.
+
+For example, consider this `.sublime-project`:
+
+```
+{
+  "build_systems":
+  [
+    {
+      "name": "My Build",
+      "shell_cmd": "c++ program.c -o program",
+      "working_dir" "$project_path"
+      "variants":
+      [
+        {
+          "name": "Run program",
+          "shell_cmd": "./program",
+          "working_dir": "$project_path"
+        }
+      ]
+    }
+  ],
+  "folders":
+  [
+    {
+      "path": "."
+    }
+  ],
+  "settings":
+  {
+  }
+}
+```
+When you click on *Tools* -> *Build With...* in the menu, you may select the
+*My Build - Run program* variant. This will open an output panel and run your
+program. Unfortunately, if the program wants input from user, you cannot type
+on your keyboard to send that input to the program. To solve this you can change
+the variant to:
+```
+        {
+          "name": "Run program",
+          "target": "terminal_view_exec",
+          "shell_cmd": "./program",
+          "working_dir": "$project_path"
+        }
+```
+This will run your program inside a TerminalView instead. You will be able to
+supply input with the keyboard.
+<sup>Note: the default value for the `"target"` is the `"exec"` command.</sup>
+
+At this point, a custom `"env"` key is not yet supported.
+
 ## Common problems
 List of common problems you may encounter when using this plugin.
 

--- a/TerminalView.py
+++ b/TerminalView.py
@@ -45,7 +45,12 @@ class TerminalViewOpen(sublime_plugin.WindowCommand):
     class per sublime window. Once a terminal view has been opened the
     TerminalViewActivate instance for that view is called to handle everything.
     """
-    def run(self, cmd="/bin/bash -l", title="Terminal", cwd=None, syntax=None):
+    def run(self,
+            cmd="/bin/bash -l",
+            title="Terminal",
+            cwd=None,
+            syntax=None,
+            autoclose=True):
         """
         Open a new terminal view
 
@@ -74,7 +79,9 @@ class TerminalViewOpen(sublime_plugin.WindowCommand):
             cwd = "/"
 
         args = {"cmd": cmd, "title": title, "cwd": cwd, "syntax": syntax}
-        self.window.new_file().run_command("terminal_view_activate", args=args)
+        view = self.window.new_file()
+        view.settings().set("terminal_view_close_view_too", autoclose)
+        view.run_command("terminal_view_activate", args=args)
 
 
 class TerminalViewActivate(sublime_plugin.TextCommand):

--- a/TerminalView.py
+++ b/TerminalView.py
@@ -159,15 +159,16 @@ class TerminalView:
             self._poll_shell_output(timeout=update_rate)
             self._terminal_buffer.update_view()
             self._resize_screen_if_needed()
-            if (not self._terminal_buffer.is_open()) or (not self._shell.is_running()):
-                self._stop()
+            if not self._shell.is_running():
+                self._poll_shell_output(timeout=0)
                 break
+        self._stop()
 
     def _poll_shell_output(self, timeout=0):
         """
         Poll the output of the shell
         """
-        max_read_size = 4096
+        max_read_size = 2**12
         data = self._shell.receive_output(max_read_size, timeout=timeout)
         if data is not None:
             utils.ConsoleLogger.log("Got %u bytes of data from shell" % (len(data), ))

--- a/TerminalView.py
+++ b/TerminalView.py
@@ -50,7 +50,7 @@ class TerminalViewOpen(sublime_plugin.WindowCommand):
             title="Terminal",
             cwd=None,
             syntax=None,
-            autoclose=True):
+            keep_open=False):
         """
         Open a new terminal view
 
@@ -80,7 +80,7 @@ class TerminalViewOpen(sublime_plugin.WindowCommand):
 
         args = {"cmd": cmd, "title": title, "cwd": cwd, "syntax": syntax}
         view = self.window.new_file()
-        view.settings().set("terminal_view_close_view_too", autoclose)
+        view.settings().set("terminal_view_keep_open", keep_open)
         view.run_command("terminal_view_activate", args=args)
 
 

--- a/exec.py
+++ b/exec.py
@@ -6,7 +6,7 @@ class TerminalViewExec(sublime_plugin.WindowCommand):
 
     _init_args = {}
 
-    def run(self, *args, **kwargs):
+    def run(self, **kwargs):
         name = kwargs.get("name", "Executable")
         env = kwargs.get("env", {})
         env = os.environ.copy().update(env)
@@ -55,5 +55,5 @@ class TerminalViewExec(sublime_plugin.WindowCommand):
                                     "cmd": cmd,
                                     "cwd": cwd,
                                     "title": title,
-                                    "autoclose": False
+                                    "keep_open": True
                                 })

--- a/exec.py
+++ b/exec.py
@@ -1,0 +1,29 @@
+import os
+import sublime_plugin
+
+
+class TerminalViewExec(sublime_plugin.WindowCommand):
+
+    def run(self, *args, **kwargs):
+        name = kwargs.get("name", "Executable")
+        env = kwargs.get("env", {})
+        env = os.environ.copy().update(env)
+        cmd = kwargs.get("cmd", [])
+        if not cmd:
+            cmd = [kwargs.get("shell_cmd", "")]
+        working_dir = kwargs.get("working_dir")
+        if not working_dir:
+            view = self.window.active_view()
+            if view and view.file_name():
+                working_dir = os.path.basedir(view.file_name())
+            else:
+                working_dir = env.get("HOME", "")
+                if not working_dir:
+                    working_dir = "/"
+        args = kwargs.get("args", "")
+        invocation = " ".join(cmd) + args
+        self.window.run_command("terminal_view_open", args={
+                                    "cmd": invocation,
+                                    "cwd": working_dir,
+                                    "title": name,
+                                    "autoclose": False})

--- a/exec.py
+++ b/exec.py
@@ -7,12 +7,20 @@ class TerminalViewExec(sublime_plugin.WindowCommand):
     _init_args = {}
 
     def run(self, **kwargs):
+        # Get the title for the view.
         name = kwargs.get("name", "Executable")
+
+        # Custom environment variables are ignored for now. LinuxPty should be
+        # able to handle that in the future.
         env = kwargs.get("env", {})
         env = os.environ.copy().update(env)
+
+        # Get the command that we'll invoke.
         cmd = kwargs.get("cmd", [])
         if not cmd:
             cmd = [kwargs.get("shell_cmd", "")]
+        
+        # Get the cwd.
         working_dir = kwargs.get("working_dir")
         if not working_dir:
             view = self.window.active_view()
@@ -22,9 +30,12 @@ class TerminalViewExec(sublime_plugin.WindowCommand):
                 working_dir = env.get("HOME", "")
                 if not working_dir:
                     working_dir = "/"
+        
+        # If there's init args, get those.
         args = kwargs.get("args", "")
         invocation = " ".join(cmd)
         if not args:
+            # Otherwise, prompt the user for init args.
             self.name = name
             self.invocation = invocation
             self.working_dir = working_dir

--- a/linux_pty.py
+++ b/linux_pty.py
@@ -48,9 +48,6 @@ class LinuxPty():
         """
         Poll the shell output
         """
-        if not self.is_running():
-            return None
-
         (ready, _, _) = select.select([self._pty], [], [], timeout)
         if not ready:
             return None

--- a/sublime_terminal_buffer.py
+++ b/sublime_terminal_buffer.py
@@ -40,6 +40,7 @@ class SublimeBufferManager():
 class SublimeTerminalBuffer():
     def __init__(self, sublime_view, title, syntax_file=None):
         self._view = sublime_view
+        self._startup_time = time.time()
         self._view.set_name(title)
         self._view.set_scratch(True)
         self._view.set_read_only(True)
@@ -117,6 +118,9 @@ class SublimeTerminalBuffer():
 
     def close(self):
         if self._view.settings().get("terminal_view_keep_open", False):
+            t = time.time() - self._startup_time
+            msg = "[Finished in {0:0.1f}s]".format(t).encode("ascii")
+            self._term_emulator.feed(msg)
             self.update_view()
         elif self.is_open():
             sublime.active_window().focus_view(self._view)

--- a/sublime_terminal_buffer.py
+++ b/sublime_terminal_buffer.py
@@ -113,8 +113,15 @@ class SublimeTerminalBuffer():
 
     def close(self):
         if self.is_open():
-            sublime.active_window().focus_view(self._view)
-            sublime.active_window().run_command("close_file")
+            if self._view.settings().get("terminal_view_close_view_too", True):
+                sublime.active_window().focus_view(self._view)
+                sublime.active_window().run_command("close_file")
+            else:
+                # flush output
+                import TerminalView
+                term = TerminalView.TerminalView.TerminalViewManager.load_from_id(self._view.id())
+                output = term._shell.receive_output(4000)
+                print(output)
         SublimeBufferManager.deregister(self._view.id())
         self._keypress_callback = None
 

--- a/sublime_terminal_buffer.py
+++ b/sublime_terminal_buffer.py
@@ -117,11 +117,7 @@ class SublimeTerminalBuffer():
                 sublime.active_window().focus_view(self._view)
                 sublime.active_window().run_command("close_file")
             else:
-                # flush output
-                import TerminalView
-                term = TerminalView.TerminalView.TerminalViewManager.load_from_id(self._view.id())
-                output = term._shell.receive_output(4000)
-                print(output)
+                self.update_view()  # one last time?
         SublimeBufferManager.deregister(self._view.id())
         self._keypress_callback = None
 

--- a/sublime_terminal_buffer.py
+++ b/sublime_terminal_buffer.py
@@ -112,7 +112,9 @@ class SublimeTerminalBuffer():
         return self._view.is_valid()
 
     def close(self):
-        if self.is_open() and not self._view.settings().get("terminal_view_keep_open", False):
+        if self._view.settings().get("terminal_view_keep_open", False):
+            self.update_view()
+        elif self.is_open():
             sublime.active_window().focus_view(self._view)
             sublime.active_window().run_command("close_file")
         SublimeBufferManager.deregister(self._view.id())


### PR DESCRIPTION
This adds a command called TerminalViewExecCommand. In a Sublime build system, you can use this command for the `"target"` value. You can then use the keyboard to give input to whatever command that you're building/executing.

For example, consider this `.sublime-project`:

```json
{
  "build_systems":
  [
    {
      "name": "My Build",
      "shell_cmd": "c++ program.c -o program",
      "working_dir" "${project_path}"
      "variants":
      [
        {
          "name": "Run program",
          "shell_cmd": "./program",
          "working_dir": "${project_path}"
        }
      ]
    }
  ],
  "folders":
  [
    {
      "path": "."
    }
  ],
  "settings":
  {
  }
}
```
A problem occurs when `./program` wants input interactively. You cannot pass this information with the current command that runs (`exec`). So, you can replace it with:
```json
        {
          "target": "terminal_view_exec",
          "name": "Run program",
          "shell_cmd": "./program",
          "working_dir": "${project_path}"
        }
```
and that should be all that's necessary.

One problem I'm encountering though, is that when the program exits, the tab is closed automatically too. Do you have any suggestions on fixing this? My thought was to add an `autoclose` argument. That gets saved in the settings object as `"terminal_view_close_view_too"`. Normally, this is always set to `True`. When it's `False`, the SublimeTerminalBuffer should not close the view but instead flush the last remaining output. It's almost working but I need to do a few more tweaks.