### PR TITLE
support CPR

### DIFF
--- a/TerminalView.py
+++ b/TerminalView.py
@@ -126,6 +126,7 @@ class TerminalView:
         self._terminal_buffer = \
             sublime_terminal_buffer.SublimeTerminalBuffer(self.view, title, syntax)
         self._terminal_buffer.set_keypress_callback(self.keypress_callback)
+        self._terminal_buffer.set_write_process_input_callback(self.send_string_to_shell)
         self._terminal_buffer_is_open = True
         self._terminal_rows = 0
         self._terminal_columns = 0

--- a/pyte_terminal_emulator.py
+++ b/pyte_terminal_emulator.py
@@ -267,6 +267,25 @@ class CustomHistoryScreen(pyte.DiffScreen):
         # Update tabstops to new screen size
         self.tabstops = set(range(8, self.columns, 8))
 
+    def report_device_status(self, mode):
+        """Reports terminal status or cursor position.
+
+        :param int mode: if 5 -- terminal status, 6 -- cursor position,
+                         otherwise a noop.
+
+        .. versionadded:: 0.5.0
+        """
+        if mode == 5:    # Request for terminal status.
+            self.write_process_input("\x1b[" + "0n")
+        elif mode == 6:  # Request for cursor position.
+            x = self.cursor.x + 1
+            y = self.cursor.y + 1
+
+            # "Origin mode (DECOM) selects line numbering."
+            if modes.DECOM in self.mode:
+                y -= self.margins.top
+            self.write_process_input("{0}{1};{2}R".format("\x1b[", y, x))
+
 
 def take(n, iterable):
     """Returns first n items of the iterable as a list."""

--- a/sublime_terminal_buffer.py
+++ b/sublime_terminal_buffer.py
@@ -73,6 +73,7 @@ class SublimeTerminalBuffer():
         self._term_emulator = pyte_terminal_emulator.PyteTerminalEmulator(80, 24, hist, ratio)
 
         self._keypress_callback = None
+        self._write_process_input_callback = None
         self._view_content_cache = sublime_view_cache.SublimeViewContentCache()
         self._view_region_cache = sublime_view_cache.SublimeViewRegionCache()
 
@@ -82,6 +83,9 @@ class SublimeTerminalBuffer():
 
     def __del__(self):
         utils.ConsoleLogger.log("Sublime buffer instance deleted")
+
+    def set_write_process_input_callback(self, callback):
+        self._term_emulator._screen.write_process_input = callback
 
     def set_keypress_callback(self, callback):
         self._keypress_callback = callback


### PR DESCRIPTION
close #55 

the function `report_device_status` is copied from `pyte` by changing `\x9b` to `\x1b[`