### PR TITLE
Use shlex to split the command arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ contexts:
 The matching could be improved upon but it will do for the purpose of this example. Note that the scope names are chosen so they match with scopes that are already defined in the color scheme. To change the color scheme see the "color scheme" section above. In this example the syntax file was saved as *bash.sublime-syntax* under the *Packages/User* folder. To use it when opening a bash terminal pass it to the *terminal_view_open* command with the *syntax* argument:
 
 ```
-{ "keys": ["ctrl+alt+t"], "command": "terminal_view_open", "args": {"cmd": "/bin/bash -l", "title": "Bash Terminal", "syntax": "bash.sublime-syntax"}},
+{ "keys": ["ctrl+alt+t"], "command": "terminal_view_open", "args": {"cmd": ["/bin/bash", "-l"], "title": "Bash Terminal", "syntax": "bash.sublime-syntax"}},
 ```
 
 There are currently no syntax-files provided with the plugin so users must create their own. Note that any colors set by shell (except the black/white default) override colors set by the syntax highlighting.

--- a/TerminalView.py
+++ b/TerminalView.py
@@ -6,6 +6,7 @@ initializing a terminal view
 import os
 import threading
 import time
+import shlex  # for split()
 
 import sublime
 import sublime_plugin
@@ -119,7 +120,7 @@ class TerminalView:
         self._keep_open = keep_open
 
         # Start the underlying shell
-        self._shell = linux_pty.LinuxPty(self._cmd.split(), self._cwd)
+        self._shell = linux_pty.LinuxPty(shlex.split(self._cmd), self._cwd)
         self._shell_is_running = True
 
         # Initialize the sublime view

--- a/TerminalView.py
+++ b/TerminalView.py
@@ -106,10 +106,6 @@ class TerminalViewActivate(sublime_plugin.TextCommand):
             if not cwd:
                 cwd = "/"
             terminal_view.run(cmd, title, cwd, syntax, keep_open)
-        except KeyError as e:
-            # KeyError gets thrown by LinuxPty when cmd[0] doesn't exist.
-            sublime.error_message(str(e))
-            return
 
 
 class TerminalView:

--- a/TerminalView.sublime-commands
+++ b/TerminalView.sublime-commands
@@ -2,13 +2,13 @@
   {
     "caption": "Terminal View: Open Bash Terminal",
     "command": "terminal_view_open",
-    "args"   : {"title": "Terminal (bash)", "cmd": "/bin/bash -l"},
+    "args"   : {"title": "Terminal (bash)"},
   },
   // Example of a new command that can be added to the pallete
   // {
   //   "caption": "Terminal View: Open IPython Terminal",
   //   "command": "terminal_view_open",
-  //   "args"   : {"title": "Terminal (IPython)", "cmd": "/bin/bash -l -c /usr/bin/ipython"},
+  //   "args"   : {"title": "Terminal (IPython)", "cmd": ["/bin/bash", "-l", "-c", "/usr/bin/ipython"]},
   // },
   {
     "caption": "Preferences: Terminal View: Settings",

--- a/exec.py
+++ b/exec.py
@@ -1,5 +1,6 @@
 import os
 import sublime_plugin
+import shlex
 
 
 class TerminalViewExec(sublime_plugin.WindowCommand):
@@ -18,10 +19,13 @@ class TerminalViewExec(sublime_plugin.WindowCommand):
         # Get the command that we'll invoke.
         cmd = kwargs.get("cmd", [])
         if not cmd:
-            cmd = [kwargs.get("shell_cmd", "")]
-        
+            cmd = shlex.split(kwargs.get("shell_cmd", ""))
+        if not cmd:
+            sublime.error_message('Did not find a "cmd" nor a "shell_cmd"')
+            return
+
         # Get the cwd.
-        working_dir = kwargs.get("working_dir")
+        working_dir = kwargs.get("working_dir", "")
         if not working_dir:
             view = self.window.active_view()
             if view and view.file_name():
@@ -30,18 +34,18 @@ class TerminalViewExec(sublime_plugin.WindowCommand):
                 working_dir = env.get("HOME", "")
                 if not working_dir:
                     working_dir = "/"
-        
+
         # If there's init args, get those.
         args = kwargs.get("args", "")
-        invocation = " ".join(cmd)
         if not args:
             # Otherwise, prompt the user for init args.
             self.name = name
-            self.invocation = invocation
+            self.cmd = cmd
             self.working_dir = working_dir
+            self.invocation = " ".join(cmd)
             # Retrieve the init args for lazy people
-            cached_args = self.__class__._init_args.get(invocation, "")
-            title = 'Arguments for "{}" '.format(invocation)
+            cached_args = self.__class__._init_args.get(self.invocation, "")
+            title = 'Arguments for "{}" '.format(self.invocation)
             if cached_args:
                 title += ":"
             else:
@@ -52,13 +56,12 @@ class TerminalViewExec(sublime_plugin.WindowCommand):
                                          None,
                                          None)
         else:
-            self._run(invocation, working_dir, name)
+            self._run(cmd + shlex.split(args), working_dir, name)
 
     def _on_done(self, text):
         # Cache the init args for lazy people
         self.__class__._init_args[self.invocation] = text
-        self.invocation += " " + text
-        self._run(self.invocation, self.working_dir, self.name)
+        self._run(self.cmd + shlex.split(text), self.working_dir, self.name)
 
     def _run(self, cmd, cwd, title):
         self.window.run_command("terminal_view_open",

--- a/exec.py
+++ b/exec.py
@@ -1,6 +1,7 @@
 import os
 import sublime_plugin
 import shlex
+import sublime
 
 
 class TerminalViewExec(sublime_plugin.WindowCommand):


### PR DESCRIPTION
This allows proper use of quotes in the command. For example, using

/bin/bash -c 'ssh example.com'

is now split into

- "/bin/bash"
- "-c"
- "ssh example.com"

which allows for extra arguments after the `-c` option of bash.

I believe this fixes https://github.com/Wramberg/TerminalView/issues/62.