### PR TITLE
support cursor position report

### DIFF
--- a/TerminalView.py
+++ b/TerminalView.py
@@ -135,6 +135,7 @@ class TerminalView:
         self._terminal_buffer = \
             sublime_terminal_buffer.SublimeTerminalBuffer(self.view, title, syntax)
         self._terminal_buffer.set_keypress_callback(self.keypress_callback)
+        self._terminal_buffer.set_write_process_input_callback(self.send_string_to_shell)
         self._terminal_buffer_is_open = True
         self._terminal_rows = 0
         self._terminal_columns = 0

--- a/pyte_terminal_emulator.py
+++ b/pyte_terminal_emulator.py
@@ -274,6 +274,23 @@ class CustomHistoryScreen(pyte.DiffScreen):
         # Update tabstops to new screen size
         self.tabstops = set(range(8, self.columns, 8))
 
+    def report_device_attributes(self, mode=0, **kwargs):
+
+        if mode == 0 and not kwargs.get("private"):
+            self.write_process_input("\x1b[" + "?6c")
+
+    def report_device_status(self, mode):
+        if mode == 5:    # Request for terminal status.
+            self.write_process_input("\x1b[" + "0n")
+        elif mode == 6:  # Request for cursor position.
+            x = self.cursor.x + 1
+            y = self.cursor.y + 1
+
+            # "Origin mode (DECOM) selects line numbering."
+            if modes.DECOM in self.mode:
+                y -= self.margins.top
+            self.write_process_input("{0}{1};{2}R".format("\x1b[", y, x))
+
 
 def take(n, iterable):
     """Returns first n items of the iterable as a list."""

--- a/sublime_terminal_buffer.py
+++ b/sublime_terminal_buffer.py
@@ -73,6 +73,7 @@ class SublimeTerminalBuffer():
         self._term_emulator = pyte_terminal_emulator.PyteTerminalEmulator(80, 24, hist, ratio)
 
         self._keypress_callback = None
+        self._write_process_input_callback = None
         self._view_content_cache = sublime_view_cache.SublimeViewContentCache()
         self._view_region_cache = sublime_view_cache.SublimeViewRegionCache()
 
@@ -82,6 +83,9 @@ class SublimeTerminalBuffer():
 
     def __del__(self):
         utils.ConsoleLogger.log("Sublime buffer instance deleted")
+
+    def set_write_process_input_callback(self, callback):
+        self._term_emulator._screen.write_process_input = callback
 
     def set_keypress_callback(self, callback):
         self._keypress_callback = callback


### PR DESCRIPTION
I have revisited my PR at #56. I finally managed to enable CPR (cursor position report) by pulling
`report_device_attributes` and `report_device_status` from `pyte` master branch.

see also selectel/pyte#71

close #55

